### PR TITLE
Disable autorefresh when setting build time.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction/index.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
-    <l:layout title="Test">
+    <l:layout title="Test" norefresh="true">
         <st:include page="sidepanel.jelly" it="${it.owner}" />
         <l:main-panel>
             <h1>${%Project} ${it.owner.name}</h1>


### PR DESCRIPTION
Otherwise it could be annoying since when
the page is refreshed the value entered is missed.

Maybe it would be a good idea to change the page title too.