### PR TITLE
Fix for JENKINS-28961

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction.java
@@ -93,7 +93,13 @@ public class ScheduleBuildAction implements Action, StaplerProxy {
                 
         return FormValidation.ok();       
     }
-       
+    long quietperiod;
+
+    public long getQuietPeriodInSeconds(){
+        return quietperiod/1000;
+    }
+
+
     public HttpResponse doNext(StaplerRequest req) throws FormException, ServletException, IOException {
         JSONObject param = StructuredForm.get(req);
         Date ddate = getDefaultDateObject(), now = new Date();
@@ -106,12 +112,12 @@ public class ScheduleBuildAction implements Action, StaplerProxy {
             }
         }
 
-        long quietperiod = ddate.getTime() - now.getTime() + ScheduleBuildAction.securityMargin; // 120 sec security margin
+        quietperiod = ddate.getTime() - now.getTime() + ScheduleBuildAction.securityMargin; // 120 sec security margin
         if (quietperiod < 0) {
             return HttpResponses.redirectTo("error");
         }
-        
-        return HttpResponses.redirectTo(getOwner().getAbsoluteUrl() + "build?delay=" + quietperiod / 1000 + "sec");
+
+        return HttpResponses.forwardToView(this, "redirect");
     }
 
     private DateFormat dateFormat() {

--- a/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction/redirect.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction/redirect.jelly
@@ -1,0 +1,39 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <l:layout title="Redirecting...">
+    <l:main-panel>
+      <!--
+        Auto submits the form to the community server
+      -->
+      <p>
+        Submitting your changes to the server...
+      </p>
+      <script>
+    var xmlhttp;
+    if(window.XMLHttpRequest){
+        xmlhttp = new XMLHttpRequest();
+    } else{
+        xmlhttp = new ActiveXObject("Microsoft.XMLHTTP");
+    }
+
+
+
+    xmlhttp.onreadystatechange = function(){
+        if(xmlhttp.readyState === 4){
+            if(xmlhttp.status === 200 || xmlhttp.status === 201){
+                 window.location="${it.owner.absoluteUrl}"
+                 return false;
+            } else {
+                 window.location="${it.owner.absoluteUrl}"
+                return false;
+            }
+        }
+    };
+    xmlhttp.open("POST", "${it.owner.absoluteUrl}build?delay=${it.quietPeriodInSeconds}sec", true);
+    xmlhttp.send();
+
+
+ </script>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction/redirect.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction/redirect.jelly
@@ -3,22 +3,19 @@
   <l:layout title="Redirecting...">
     <l:main-panel>
       <!--
-        Auto submits the form to the community server
+        Auto submits the form to the jenkins server
       -->
       <p>
         Submitting your changes to the server...
       </p>
       <script>
-    var xmlhttp;
-    if(window.XMLHttpRequest){
+      var xmlhttp;
+      if(window.XMLHttpRequest){
         xmlhttp = new XMLHttpRequest();
-    } else{
+      } else{
         xmlhttp = new ActiveXObject("Microsoft.XMLHTTP");
-    }
-
-
-
-    xmlhttp.onreadystatechange = function(){
+      }
+      xmlhttp.onreadystatechange = function(){
         if(xmlhttp.readyState === 4){
             if(xmlhttp.status === 200 || xmlhttp.status === 201){
                  window.location="${it.owner.absoluteUrl}"
@@ -28,12 +25,10 @@
                 return false;
             }
         }
-    };
-    xmlhttp.open("POST", "${it.owner.absoluteUrl}build?delay=${it.quietPeriodInSeconds}sec", true);
-    xmlhttp.send();
-
-
- </script>
+      };
+      xmlhttp.open("POST", "${it.owner.absoluteUrl}build?delay=${it.quietPeriodInSeconds}sec", true);
+      xmlhttp.send();
+      </script>
     </l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION
When scheduling a build the current version redirects to a blank page.
This version redirects to the project page. This is achieved with an intermediate page that starts the build with an ajax request and redirects after completion of scheduling.