### PR TITLE
Use parent pom 4.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 
   <properties>
     <java.level>8</java.level>
+    <jenkins.version>2.289.1</jenkins.version>
   </properties>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,9 @@
   <properties>
     <java.level>8</java.level>
     <jenkins.version>2.289.1</jenkins.version>
+    <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.failOnError>true</spotbugs.failOnError>
+    <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.50</version>
+    <version>4.27</version>
   </parent>
 
   <artifactId>schedule-build</artifactId>


### PR DESCRIPTION
## Use parent pom 4.27

Allow Java 11 compile, new development.

Mark Waite is using this repository as an example of adopting a plugin by submitting a series of small improvement pull requests.
