### PR TITLE
Use https instead of git SCM URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/schedule-build-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/schedule-build-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/schedule-build-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/schedule-build-plugin</url>
     <tag>HEAD</tag>


### PR DESCRIPTION
use https protocol instead of git protocol because GitHub is deprecating git protocol

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
