### PR TITLE
Add MarkEWaite as a plugin maintainer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
       <name>Martin Spielmann</name>
       <email>mail@martinspielmann.de</email>
     </developer>
+    <developer>
+      <id>MarkEWaite</id>
+      <name>Mark Waite</name>
+      <email>mark.earl.waite@gmail.com</email>
+    </developer>
   </developers>
   
   <licenses>


### PR DESCRIPTION
# Add MarkEWaite as a plugin maintainer

Adopted the plugin as part of Hacktoberfest 2021
