### PR TITLE
Reduce IDE warnings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction.java
@@ -68,7 +68,7 @@ public class ScheduleBuildAction implements Action, StaplerProxy {
     }
 
     public String getIconPath() {
-        Jenkins instance = Jenkins.getInstance();
+        Jenkins instance = Jenkins.getInstanceOrNull();
         if (instance != null) {
             String rootUrl = instance.getRootUrl();
 


### PR DESCRIPTION
## Reduce warnings from Netbeans IDE

* Use all upper case for Java constants
* Use non-deprecated get() method on Jenkins object

## Checklist

- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Refactoring (behavior preserving improvement)
