### PR TITLE
Provide working JCasC example without defaultScheduleTime attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Add to your yaml file:
 ```yaml
 unclassified:
   scheduleBuild:
-    defaultScheduleTime: 23:00:00
-    timeZone: Europe/Paris
+    # defaultScheduleTime is not currently supported in JCasC
+    # See JENKINS-66939 for more details
+    # defaultScheduleTime: "11:00:00 PM"
+    timeZone: "Europe/Paris"
 ```


### PR DESCRIPTION
## [JENKINS-66939](https://issues.jenkins.io/browse/JENKINS-66939) - Provide working JCasC example without defaultScheduleTime attribute

Fix the configuration as code documentation so that it works as expected for `timeZone`.  The timeZone value is a quoted string.

Document the configuration as code failure that is reported when the `defaultScheduleTime` attribute is assigned a value.

Does **NOT** resolve [JENKINS-66939](https://issues.jenkins.io/browse/JENKINS-66939), just documents the portion of configuration as code that is known to work and describes the failure so that users may be aware of the configuration failure.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Documentation update
