### PR TITLE
Add JCasC round trip test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,27 @@
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.289.x</artifactId>
+        <version>961.vf0c9f6f59827</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- JCasC test dependency -->
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/JCasCGlobalConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/JCasCGlobalConfigurationTest.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.schedulebuild;
+
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class JCasCGlobalConfigurationTest extends RoundTripAbstractTest {
+
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule j, String configContent) {
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "timeZone = Europe/Paris";
+    }
+
+    @Override
+    protected String configResource() {
+        return "scheduleBuild-default-time-zone.yaml";
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/schedulebuild/scheduleBuild-default-time-zone.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/schedulebuild/scheduleBuild-default-time-zone.yaml
@@ -1,0 +1,6 @@
+unclassified:
+  scheduleBuild:
+    # defaultScheduleTime is not currently supported in JCasC
+    # See JENKINS-66939 for more details
+    # defaultScheduleTime: "11:00:00 PM"
+    timeZone: "Europe/Paris"


### PR DESCRIPTION
## [JENKINS-66939](https://issues.jenkins.io/browse/JENKINS-66939) - Configuration as code test

Test that avoiding [JENKINS-66939](https://issues.jenkins.io/browse/JENKINS-66939) allows configuration as code to configure Jenkins with schedule build plugin settings.

Does **NOT** test JENKINS-66939.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/schedule-build-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test
