### PR TITLE
Sort pom and use common settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <packaging>hpi</packaging>
   <description>Schedule a build for a specific time</description>
   <url>https://github.com/jenkinsci/schedule-build-plugin</url>
+  <inceptionYear>2014</inceptionYear>
   
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>4.32</version>
+    <relativePath></relativePath>
   </parent>
 
   <artifactId>schedule-build</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
               <endWithNewline></endWithNewline>
               <removeUnusedImports></removeUnusedImports>
             </java>
+            <pom>
+              <indent>
+                <spaces>true</spaces>
+              </indent>
+              <sortPom></sortPom>
+            </pom>
           </configuration>
           <executions>
             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -9,12 +10,19 @@
 
   <artifactId>schedule-build</artifactId>
   <version>${changelist}</version>
-  <name>Schedule Build Plugin</name>
   <packaging>hpi</packaging>
+  <name>Schedule Build Plugin</name>
   <description>Schedule a build for a specific time</description>
   <url>https://github.com/jenkinsci/schedule-build-plugin</url>
   <inceptionYear>2014</inceptionYear>
-  
+
+  <licenses>
+    <license>
+      <name>MIT license</name>
+      <comments>All source code is under the MIT license.</comments>
+    </license>
+  </licenses>
+
   <developers>
     <developer>
       <id>anderl86</id>
@@ -32,19 +40,12 @@
       <email>mark.earl.waite@gmail.com</email>
     </developer>
   </developers>
-  
-  <licenses>
-    <license>
-      <name>MIT license</name>
-      <comments>All source code is under the MIT license.</comments>
-    </license>
-  </licenses>
 
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <properties>
@@ -63,8 +64,8 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.289.x</artifactId>
         <version>1008.vb9e22885c9cf</version>
-        <scope>import</scope>
         <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -77,6 +78,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <pluginManagement>
@@ -122,20 +138,5 @@
       </plugin>
     </plugins>
   </build>
-
-  <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
 </project>


### PR DESCRIPTION
## Sort the pom and use common entries for consistency

- Use relativePath in pom for consistency
- Add 2014 as inception year for the plugin
- Sort the pom for consistency
- Apply pom sorting

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/schedule-build-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
