### PR TITLE
Test JDK 8 and JDK 11 on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin()
+buildPlugin(failFast: false,
+            configurations: [
+                [platform: 'linux', jdk: '11'],
+                [platform: 'windows', jdk: '8'],
+            ])


### PR DESCRIPTION
## Test JDK 8 and JDK 11 on CI

JDK 8 support will eventually be dropped.  Test both JDK 8 and JDK 11 until JDK 8 is no longer supported by the Jenkins project.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/schedule-build-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
