### PR TITLE
chore(Jenkinsfile): try the Artifact Caching Proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
 buildPlugin(failFast: false,
+            // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
+            // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
+            artifactCachingProxyEnabled: true,
             configurations: [
                 [platform: 'linux',   jdk: '17', jenkins: '2.342'],
                 [platform: 'linux', jdk: '11'],


### PR DESCRIPTION
## [Helpdesk-2752](https://github.com/jenkins-infra/helpdesk/issues/2752) (Infra) Opt-in for the Artifact Caching Proxy

This PR activates the use of an Artifact Caching Proxy caching the requests done to repo.jenkins-ci.org sponsored by JFrog, in order to reduce our bandwidth consumption.
This is done by setting the new `artifactCachingProxyEnabled` parameter [recently added](https://github.com/jenkins-infra/pipeline-library/pull/502) to the shared pipeline library `buildPlugin` function.

Apart from an additional build log entry with the proxy provider configured for Maven depending on the agent location, there shouldn't be any change for any maintainer of this plugin, if there is any problem please describe it [in the related help desk issue](https://github.com/jenkins-infra/helpdesk/issues/2752).

This plugin has been chosen to check in situ this functionality (for now proposed as opt-in), [among some others](https://github.com/jenkins-infra/helpdesk/issues/2752#issuecomment-1287013172).

There will be another PR to remove these changes as soon as the functionality would have been approved and switched to opt-out.

cc @MarkEWaite

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/schedule-build-plugin/blob/master/CONTRIBUTING.md) doc
- [X] I have referenced the Jira issue related to my changes in one or more commit messages
- [X] I have added tests that verify my changes
- [X] Unit tests pass locally with my changes
- [X] I have added documentation as necessary
- [X] No spotbugs warnings were introduced with my changes
- [X] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply, remove the rows that do not apply_.

- [ ] Dependency update
- [ ] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Jenkins Infrastructure change
