### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/schedule-build-plugin</gitHubRepo>
-    <jenkins.version>2.332.4</jenkins.version>
+    <jenkins.version>2.346.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.346.x</artifactId>
         <version>1678.vc1feb_6a_3c0f1</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

- [X] I have read the [CONTRIBUTING](https://github.com/jenkinsci/schedule-build-plugin/blob/master/CONTRIBUTING.md) doc
- [X] Unit tests pass locally with my changes
- [X] No spotbugs warnings were introduced with my changes
- [X] I have interactively tested my changes
