### PR TITLE
Check dependencies monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,18 @@
 version: 2
 updates:
-- package-ecosystem: maven
+- package-ecosystem: "maven"
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  target-branch: master
+    interval: "monthly"
   reviewers:
   - MarkEWaite
   labels:
   - skip-changelog
-- package-ecosystem: github-actions
+- package-ecosystem: "github-actions"
   directory: /
   schedule:
-    interval: weekly
+    interval: "monthly"
+  reviewers:
+  - MarkEWaite
+  labels:
+  - skip-changelog


### PR DESCRIPTION
Not active enough to justify checking more frequently than once a month.
