### PR TITLE
Format code with Palantir Java Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,12 +106,8 @@
             <!-- define a language-specific format -->
             <java>
               <!-- no need to specify files, inferred automatically -->
-              <!-- apply a specific flavor of google-java-format -->
-              <googleJavaFormat>
-                <version>1.15.0</version>
-                <style>AOSP</style>
-              </googleJavaFormat>
               <endWithNewline />
+              <palantirJavaFormat />
               <removeUnusedImports />
             </java>
             <pom>

--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction.java
@@ -97,8 +97,7 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
     public Date getDefaultDateObject() {
         Date buildtime = new Date(),
                 now = new Date(),
-                defaultScheduleTime =
-                        new ScheduleBuildGlobalConfiguration().getDefaultScheduleTimeObject();
+                defaultScheduleTime = new ScheduleBuildGlobalConfiguration().getDefaultScheduleTimeObject();
         DateFormat dateFormat = dateFormat();
         try {
             now = dateFormat.parse(dateFormat.format(now));
@@ -178,18 +177,16 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
     }
 
     public boolean isJobParameterized() {
-        ParametersDefinitionProperty paramDefinitions =
-                target.getProperty(ParametersDefinitionProperty.class);
+        ParametersDefinitionProperty paramDefinitions = target.getProperty(ParametersDefinitionProperty.class);
         return paramDefinitions != null
                 && paramDefinitions.getParameterDefinitions() != null
                 && paramDefinitions.getParameterDefinitions().size() > 0;
     }
 
     private DateFormat dateFormat() {
-        Locale locale =
-                Stapler.getCurrentRequest() != null
-                        ? Stapler.getCurrentRequest().getLocale()
-                        : Locale.getDefault();
+        Locale locale = Stapler.getCurrentRequest() != null
+                ? Stapler.getCurrentRequest().getLocale()
+                : Locale.getDefault();
         DateFormat df = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM, locale);
         df.setTimeZone(new ScheduleBuildGlobalConfiguration().getTimeZoneObject());
         return df;

--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildButtonColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildButtonColumn.java
@@ -26,7 +26,8 @@ public class ScheduleBuildButtonColumn extends ListViewColumn {
         }
     }
 
-    @Extension public static final Descriptor<ListViewColumn> DESCRIPTOR = new DescriptorImpl();
+    @Extension
+    public static final Descriptor<ListViewColumn> DESCRIPTOR = new DescriptorImpl();
 
     @Override
     public Descriptor<ListViewColumn> getDescriptor() {

--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
@@ -51,10 +51,9 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
     }
 
     private DateFormat getTimeFormat() {
-        Locale locale =
-                Stapler.getCurrentRequest() != null
-                        ? Stapler.getCurrentRequest().getLocale()
-                        : Locale.getDefault();
+        Locale locale = Stapler.getCurrentRequest() != null
+                ? Stapler.getCurrentRequest().getLocale()
+                : Locale.getDefault();
         return DateFormat.getTimeInstance(DateFormat.MEDIUM, locale);
     }
 
@@ -64,8 +63,7 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
 
     @RequirePOST
     public FormValidation doCheckDefaultScheduleTime(@QueryParameter String value) {
-        Jenkins.get()
-                .checkPermission(Jenkins.ADMINISTER); // Admin permission required for global config
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER); // Admin permission required for global config
         try {
             getTimeFormat().parse(value);
         } catch (ParseException ex) {
@@ -76,8 +74,7 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
 
     @RequirePOST
     public FormValidation doCheckTimeZone(@QueryParameter String value) {
-        Jenkins.get()
-                .checkPermission(Jenkins.ADMINISTER); // Admin permission required for global config
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER); // Admin permission required for global config
         TimeZone zone = TimeZone.getTimeZone(value);
         if (StringUtils.equals(zone.getID(), value)) {
             return FormValidation.ok();
@@ -93,8 +90,7 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
         this.timeZone = null;
         if (json.containsKey("defaultScheduleTime") && json.containsKey("timeZone")) {
             try {
-                this.defaultScheduleTime =
-                        getTimeFormat().parse(json.getString("defaultScheduleTime"));
+                this.defaultScheduleTime = getTimeFormat().parse(json.getString("defaultScheduleTime"));
                 this.timeZone = json.getString("timeZone");
                 save();
                 return true;

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildActionTest.java
@@ -17,7 +17,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 public class ScheduleBuildActionTest {
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
     private ScheduleBuildAction scheduleBuildAction;
     private FreeStyleProject project;
 
@@ -43,9 +45,7 @@ public class ScheduleBuildActionTest {
 
     @Test
     public void testGetIconClassName() throws Exception {
-        assertThat(
-                scheduleBuildAction.getIconClassName(),
-                is("symbol-calendar-outline plugin-ionicons-api"));
+        assertThat(scheduleBuildAction.getIconClassName(), is("symbol-calendar-outline plugin-ionicons-api"));
         project.disable();
         assertThat(scheduleBuildAction.getIconClassName(), is(nullValue()));
     }

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfigurationTest.java
@@ -15,15 +15,16 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 public class ScheduleBuildGlobalConfigurationTest {
 
-    @Rule public final JenkinsRule j = new JenkinsRule();
+    @Rule
+    public final JenkinsRule j = new JenkinsRule();
+
     private ScheduleBuildGlobalConfiguration globalConfig = null;
 
     public ScheduleBuildGlobalConfigurationTest() {}
 
     @Before
     public void setUp() {
-        globalConfig =
-                GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
+        globalConfig = GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
     }
 
     @Test
@@ -62,11 +63,9 @@ public class ScheduleBuildGlobalConfigurationTest {
 
     @Test
     public void testBadScheduleTime() throws Exception {
-        assertThrows(
-                java.text.ParseException.class,
-                () -> {
-                    globalConfig.setDefaultScheduleTime("34:56:78");
-                });
+        assertThrows(java.text.ParseException.class, () -> {
+            globalConfig.setDefaultScheduleTime("34:56:78");
+        });
     }
 
     @Test


### PR DESCRIPTION
Google Java Format is an excellent formatter for 2-space, 100 line codebases. Its [Rectangle Rule](https://github.com/google/google-java-format/wiki/The-Rectangle-Rule) has a high degree of conceptual purity, and this works well in the context of 2-space, 100 line codebases where it was designed. If starting from scratch, or if radical changes to existing code style were on the table, this would be my ideal formatter.

For existing 4-space, 120 line codebases where radical changes to existing code style are not on the table, Google Java Format has some critical flaws. Its 4-space "AOSP" mode does not work well at all, and it was not the primary use case. In practice the combination of 4-space mode and the rectangle rule results in unreadable code for lambdas. I have complained about this on the Google Java Format issue tracker for years, but no fix appears to be on the horizon. This makes sense, because Google internally uses the 2-space non-AOSP mode. While various PRs have been submitted to fix this problem, the maintainers of Google Java Format have rejected or ignored them, likely because they all violate the conceptual purity of the Rectangle Rule.

For existing 4-space, 120 line codebases (and the Jenkins project consists largely of these) where radical changes to existing code style are not on the table, Palantir Java Format is a better choice than Google Java Format. It is a fork of Google Java Format designed for this use case with intentional violations of the Rectangle Rule. In practice it gives much better results than Google Java Format for this type of codebase.

The Maven project is reformatting its legacy codebase with Palantir Java Format and I have been impressed with how relatively uneventful it has been. Palantir Java Format works very well with this type of codebase, and Jenkins is an example of this type of codebase as well. I have successfully reformatted `plugin-compat-tester` this way in https://github.com/jenkinsci/plugin-compat-tester/pull/506 and the results are far better than Google Java Format.

As the Zen of Python states:

> Practicality beats purity.