### PR TITLE
Adapt plugin for Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,10 @@ buildPlugin(
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Test Java 11 and Java 17
+  // Test Java 11, 17, and 21
   configurations: [
     [platform: 'linux',   jdk: '17'], // Linux first for coverage report on ci.jenkins.io
+    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
     [platform: 'windows', jdk: '11'],
   ]
 )

--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
@@ -37,9 +37,13 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
     private static final LocalDate EPOCH = LocalDate.of(1970, 1, 1);
     private static final ZoneId ZONE = ZoneId.systemDefault();
     private static final DateTimeFormatter[] FORMATTERS = {
-        DateTimeFormatter.ofPattern("h:m:s a"), // Original format required by DateFormat
-        DateTimeFormatter.ofPattern("h:m:s"),
+        DateTimeFormatter.ofPattern("H:m:s a"), // Original format required by DateFormat
+        DateTimeFormatter.ofPattern("h:m:s a"),
+        DateTimeFormatter.ofPattern("H:m a"),
         DateTimeFormatter.ofPattern("h:m a"),
+        DateTimeFormatter.ofPattern("H:m:s"),
+        DateTimeFormatter.ofPattern("h:m:s"),
+        DateTimeFormatter.ofPattern("H:m"),
         DateTimeFormatter.ofPattern("h:m"),
     };
 
@@ -67,6 +71,7 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
                     LocalTime localTime = LocalTime.parse(defaultScheduleTime, formatter);
                     Instant instant = localTime.atDate(EPOCH).atZone(ZONE).toInstant();
                     this.defaultScheduleTime = Date.from(instant);
+                    // LOGGER.log(Level.FINEST, "Parsed '" + defaultScheduleTime + "' with formatter " + formatter);
                     return;
                 } catch (DateTimeParseException dtex) {
                     LOGGER.log(

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildActionTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.schedulebuild;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -89,7 +90,7 @@ public class ScheduleBuildActionTest {
 
     @Test
     public void testGetDefaultDate() throws Exception {
-        assertThat(scheduleBuildAction.getDefaultDate(), endsWith(" 10:00:00 PM"));
+        assertThat(scheduleBuildAction.getDefaultDate(), matchesPattern(".* 10:00:00\\hPM"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfigurationTest.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.schedulebuild;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.Assert.assertThrows;
 
 import java.time.ZoneId;
@@ -30,7 +31,7 @@ public class ScheduleBuildGlobalConfigurationTest {
     @Test
     public void configRoundTripTestNoChanges() throws Exception {
         assertThat(globalConfig, is(not(nullValue())));
-        assertThat(globalConfig.getDefaultScheduleTime(), is("10:00:00 PM"));
+        assertThat(globalConfig.getDefaultScheduleTime(), matchesPattern("10:00:00\\hPM"));
         assertThat(globalConfig.getTimeZone(), is(TimeZone.getDefault().getID()));
 
         // Submit the global configuration page with no changes
@@ -39,7 +40,7 @@ public class ScheduleBuildGlobalConfigurationTest {
         ScheduleBuildGlobalConfiguration newGlobalConfig =
                 GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
         assertThat(newGlobalConfig, is(not(nullValue())));
-        assertThat(newGlobalConfig.getDefaultScheduleTime(), is("10:00:00 PM"));
+        assertThat(newGlobalConfig.getDefaultScheduleTime(), matchesPattern("10:00:00\\hPM"));
         assertThat(newGlobalConfig.getTimeZone(), is(TimeZone.getDefault().getID()));
     }
 
@@ -57,7 +58,7 @@ public class ScheduleBuildGlobalConfigurationTest {
         ScheduleBuildGlobalConfiguration newGlobalConfig =
                 GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
         assertThat(newGlobalConfig, is(not(nullValue())));
-        assertThat(newGlobalConfig.getDefaultScheduleTime(), is(newScheduleTime));
+        assertThat(newGlobalConfig.getDefaultScheduleTime(), matchesPattern("1:23:45\\hPM"));
         assertThat(newGlobalConfig.getTimeZone(), is(newTimeZone));
     }
 
@@ -79,14 +80,14 @@ public class ScheduleBuildGlobalConfigurationTest {
 
     @Test
     public void testGetDefaultScheduleTime() {
-        assertThat(globalConfig.getDefaultScheduleTime(), is("10:00:00 PM"));
+        assertThat(globalConfig.getDefaultScheduleTime(), matchesPattern("10:00:00\\hPM"));
     }
 
     @Test
     public void testSetDefaultScheduleTime() throws Exception {
         String defaultScheduleTime = "12:34:56 PM";
         globalConfig.setDefaultScheduleTime(defaultScheduleTime);
-        assertThat(globalConfig.getDefaultScheduleTime(), is(defaultScheduleTime));
+        assertThat(globalConfig.getDefaultScheduleTime(), matchesPattern("12:34:56\\hPM"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfigurationTest.java
@@ -63,6 +63,24 @@ public class ScheduleBuildGlobalConfigurationTest {
     }
 
     @Test
+    public void configRoundTripTestWithChangesSimpleTime() throws Exception {
+        // Adjust global configuration values
+        String newScheduleTime = "2:34";
+        String newTimeZone = "Europe/Rome";
+        globalConfig.setDefaultScheduleTime(newScheduleTime);
+        globalConfig.setTimeZone(newTimeZone);
+
+        // Submit the global configuration page, will not change adjusted values
+        j.configRoundtrip();
+
+        ScheduleBuildGlobalConfiguration newGlobalConfig =
+                GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
+        assertThat(newGlobalConfig, is(not(nullValue())));
+        assertThat(newGlobalConfig.getDefaultScheduleTime(), matchesPattern("2:34:00\\hAM"));
+        assertThat(newGlobalConfig.getTimeZone(), is(newTimeZone));
+    }
+
+    @Test
     public void testBadScheduleTime() throws Exception {
         assertThrows(java.text.ParseException.class, () -> {
             globalConfig.setDefaultScheduleTime("34:56:78");

--- a/src/test/resources/org/jenkinsci/plugins/schedulebuild/scheduleBuild-all-fields.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/schedulebuild/scheduleBuild-all-fields.yaml
@@ -1,4 +1,4 @@
 unclassified:
   scheduleBuild:
-    defaultScheduleTime: "12:34:56 AM"
+    defaultScheduleTime: "12:34:56"
     timeZone: "Europe/Rome"


### PR DESCRIPTION
## JENKINS-71817 - Adapt plugin for Java 21

The Java 21 `DateFormat` class will not parse strings that contain only a time component without a date component.  The plugin relies on the earlier Java behavior of parsing "10:00:00 PM" into a DateFormat for today.  That's a bad assumption that the plugin was making, but the assumption exists and users may be relying on the assumption.

Java 21 date string output has changed from a space character to a Unicode short space character.  That change required some test changes.  https://github.com/jenkinsci/token-macro-plugin/pull/191 shows a technique to handle that portably across multiple Java versions.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/schedule-build-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

More changes are required before this pull request can be considered.  Automated tests are failing due to unparseable date.