### PR TITLE
[JENKINS-47876] fix url of jobs in subfolder of views

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildButtonColumn/column.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildButtonColumn/column.jelly
@@ -3,7 +3,8 @@
     <td class="jenkins-table__cell--tight">
         <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
              <div class="jenkins-table__cell__button-wrapper">
-                 <a href="job/${job.name}/schedule" tooltip="${%ScheduleBuildColumn.Title}" class="jenkins-table__button">
+                 <j:set var="href" value="${jobBaseUrl}${job.shortUrl}schedule"/>
+                 <a href="${href}" tooltip="${%ScheduleBuildColumn.Title}" class="jenkins-table__button">
                      <l:icon src="symbol-calendar-outline plugin-ionicons-api" />
                  </a>
              </div>


### PR DESCRIPTION
## [JENKINS-47876](https://issues.jenkins.io/browse/JENKINS-47876) - fix url of jobs in subfolder of views

when a view includes jobs from subfolder the url is not properly calculated.


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/schedule-build-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply, remove the rows that do not apply_.

- [x] Bug fix (non-breaking change which fixes an issue)
