### PR TITLE
Remove spotbugs version declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,6 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.version>2.401.3</jenkins.version>
-    <!-- TODO: Remove when plugin pom is using this version or newer -->
-    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
-    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>


### PR DESCRIPTION
## Remove spotbugs version declaration

The spotbugs version declaration is no longer needed with most recent plugin pom.  Rely on the value from the parent pom.

### Testing done

Confirmed that there are no spotbugs changes when `mvn clean -DskipTests verify` is run.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
