### PR TITLE
[JENKINS-75717] Compilazione, not Costruzione for job in Italian

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/schedulebuild/Messages_it.properties
+++ b/src/main/resources/org/jenkinsci/plugins/schedulebuild/Messages_it.properties
@@ -1,6 +1,6 @@
-ScheduleBuildButtonColumn.DisplayName = Pianifica Costruzioni
+ScheduleBuildButtonColumn.DisplayName = Pianifica Compilazioni
 
-ScheduleBuildAction.DisplayName = Pianifica Costruzioni
+ScheduleBuildAction.DisplayName = Pianifica Compilazione
 ScheduleBuildAction.ParsingError = Non \u00e8 un tempo di generazione valido
 ScheduleBuildAction.DateInPastError = La build non pu\u00f2 essere programmata nel passato
 

--- a/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration/config_it.properties
+++ b/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration/config_it.properties
@@ -1,3 +1,3 @@
 Section_Title = Schedule Build Plugin
-DefaultScheduleBuildTime = Orario Predefinito Di Costruzione Pianificazione
+DefaultScheduleBuildTime = Orario Predefinito Di Compilazione Pianificazione
 TimeZone = Zona oraria


### PR DESCRIPTION
## [JENKINS-75717] Compilazione, not Costruzione for job in Italian

https://issues.jenkins.io/browse/JENKINS-75717 says:

> The "Build" word in the Italian Jenkins localization is usually translated
> as "Compilazione" not "Costruzione".
> 
> I think something like "Pianifica compilazione" is a better translation
> over "Pianifica Costruzioni" and better express the button purpose.

### Testing done

None.  Rely on ci.jenkins.io to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
