### PR TITLE
Turn ScheduleBuildGlobalConfiguration into a singleton

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction.java
@@ -88,7 +88,7 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
     }
 
     public ZonedDateTime getDefaultDateObject() {
-        ZonedDateTime zdt = new ScheduleBuildGlobalConfiguration().getDefaultScheduleTimeObject();
+        ZonedDateTime zdt = ScheduleBuildGlobalConfiguration.get().getDefaultScheduleTimeObject();
         ZonedDateTime now = ZonedDateTime.now();
         if (now.isAfter(zdt)) {
             zdt = zdt.plusDays(1);
@@ -98,7 +98,8 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
 
     public String getMinDate() {
         ZonedDateTime now = ZonedDateTime.now();
-        ZonedDateTime zonedNow = now.withZoneSameInstant(new ScheduleBuildGlobalConfiguration().getZoneId());
+        ZonedDateTime zonedNow =
+                now.withZoneSameInstant(ScheduleBuildGlobalConfiguration.get().getZoneId());
         return zonedNow.format(DateTimeFormatter.ofPattern(DATE_TIME_PATTERN));
     }
 
@@ -113,7 +114,7 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
         ZonedDateTime ddate;
         try {
             ddate = parseDateTime(value.trim())
-                    .atZone(new ScheduleBuildGlobalConfiguration().getZoneId())
+                    .atZone(ScheduleBuildGlobalConfiguration.get().getZoneId())
                     .plusSeconds(SECURITY_MARGIN);
         } catch (DateTimeParseException ex) {
             return FormValidation.error(Messages.ScheduleBuildAction_ParsingError());
@@ -140,7 +141,8 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
 
         final String time = date.trim();
         try {
-            ddate = parseDateTime(time).atZone(new ScheduleBuildGlobalConfiguration().getZoneId());
+            ddate = parseDateTime(time)
+                    .atZone(ScheduleBuildGlobalConfiguration.get().getZoneId());
         } catch (DateTimeParseException ex) {
             LOGGER.log(Level.INFO, ex, () -> "Error parsing " + time);
             return HttpResponses.redirectTo("error");
@@ -181,6 +183,6 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
 
     @Restricted(NoExternalUse.class)
     public String getTimeZone() {
-        return new ScheduleBuildGlobalConfiguration().getTimeZone();
+        return ScheduleBuildGlobalConfiguration.get().getTimeZone();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
@@ -31,6 +31,16 @@ import org.kohsuke.stapler.verb.POST;
 @Extension
 @Symbol("scheduleBuild")
 public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
+
+    public static ScheduleBuildGlobalConfiguration get() {
+        final ScheduleBuildGlobalConfiguration configuration =
+                GlobalConfiguration.all().get(ScheduleBuildGlobalConfiguration.class);
+        if (configuration == null) {
+            throw new IllegalStateException(
+                    "[BUG] No configuration registered, make sure not running on an agent or that Jenkins has started properly.");
+        }
+        return configuration;
+    }
     // defaultScheduleTime is a misuse of a Date object.  Used for the
     // time portion (hours, minutes, seconds, etc.) while the date
     // portion is ignored.

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/JCasCGlobalConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/JCasCGlobalConfigurationTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.jenkins.plugins.casc.misc.junit.jupiter.AbstractRoundTripTest;
-import jenkins.model.GlobalConfiguration;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -15,8 +14,7 @@ class JCasCGlobalConfigurationTest extends AbstractRoundTripTest {
 
     @Override
     protected void assertConfiguredAsExpected(JenkinsRule j, String configContent) {
-        ScheduleBuildGlobalConfiguration globalConfig =
-                GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
+        ScheduleBuildGlobalConfiguration globalConfig = ScheduleBuildGlobalConfiguration.get();
         assertThat(globalConfig, is(not(nullValue())));
         assertThat(globalConfig.getDefaultStartTime(), is("22:00:00"));
         assertThat(globalConfig.getTimeZone(), is("Europe/Paris"));

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/JCasCGlobalNewFieldsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/JCasCGlobalNewFieldsTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.jenkins.plugins.casc.misc.junit.jupiter.AbstractRoundTripTest;
-import jenkins.model.GlobalConfiguration;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -15,8 +14,7 @@ class JCasCGlobalNewFieldsTest extends AbstractRoundTripTest {
 
     @Override
     protected void assertConfiguredAsExpected(JenkinsRule j, String configContent) {
-        ScheduleBuildGlobalConfiguration globalConfig =
-                GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
+        ScheduleBuildGlobalConfiguration globalConfig = ScheduleBuildGlobalConfiguration.get();
         assertThat(globalConfig, is(not(nullValue())));
         assertThat(globalConfig.getDefaultStartTime(), is("21:34:00"));
         assertThat(globalConfig.getTimeZone(), is("Europe/Berlin"));

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/JCasCGlobalOldFieldsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/JCasCGlobalOldFieldsTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.jenkins.plugins.casc.misc.junit.jupiter.AbstractRoundTripTest;
-import jenkins.model.GlobalConfiguration;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -15,8 +14,7 @@ class JCasCGlobalOldFieldsTest extends AbstractRoundTripTest {
 
     @Override
     protected void assertConfiguredAsExpected(JenkinsRule j, String configContent) {
-        ScheduleBuildGlobalConfiguration globalConfig =
-                GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
+        ScheduleBuildGlobalConfiguration globalConfig = ScheduleBuildGlobalConfiguration.get();
         assertThat(globalConfig, is(not(nullValue())));
         assertThat(globalConfig.getDefaultStartTime(), is("00:34:56"));
         assertThat(globalConfig.getTimeZone(), is("Europe/Rome"));

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfigurationTest.java
@@ -10,7 +10,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.TimeZone;
-import jenkins.model.GlobalConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -26,7 +25,7 @@ class ScheduleBuildGlobalConfigurationTest {
     @BeforeEach
     void setUp(JenkinsRule j) {
         this.j = j;
-        globalConfig = GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
+        globalConfig = ScheduleBuildGlobalConfiguration.get();
     }
 
     @Test
@@ -38,8 +37,7 @@ class ScheduleBuildGlobalConfigurationTest {
         // Submit the global configuration page with no changes
         j.configRoundtrip();
 
-        ScheduleBuildGlobalConfiguration newGlobalConfig =
-                GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
+        ScheduleBuildGlobalConfiguration newGlobalConfig = ScheduleBuildGlobalConfiguration.get();
         assertThat(newGlobalConfig, is(not(nullValue())));
         assertThat(newGlobalConfig.getDefaultStartTime(), is("22:00:00"));
         assertThat(newGlobalConfig.getTimeZone(), is(TimeZone.getDefault().getID()));
@@ -56,8 +54,7 @@ class ScheduleBuildGlobalConfigurationTest {
         // Submit the global configuration page, will not change adjusted values
         j.configRoundtrip();
 
-        ScheduleBuildGlobalConfiguration newGlobalConfig =
-                GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
+        ScheduleBuildGlobalConfiguration newGlobalConfig = ScheduleBuildGlobalConfiguration.get();
         assertThat(newGlobalConfig, is(not(nullValue())));
         assertThat(newGlobalConfig.getDefaultStartTime(), is("13:23:45"));
         assertThat(newGlobalConfig.getTimeZone(), is(newTimeZone));
@@ -74,8 +71,7 @@ class ScheduleBuildGlobalConfigurationTest {
         // Submit the global configuration page, will not change adjusted values
         j.configRoundtrip();
 
-        ScheduleBuildGlobalConfiguration newGlobalConfig =
-                GlobalConfiguration.all().getInstance(ScheduleBuildGlobalConfiguration.class);
+        ScheduleBuildGlobalConfiguration newGlobalConfig = ScheduleBuildGlobalConfiguration.get();
         assertThat(newGlobalConfig, is(not(nullValue())));
         assertThat(newGlobalConfig.getDefaultStartTime(), is("02:34:00"));
         assertThat(newGlobalConfig.getTimeZone(), is(newTimeZone));


### PR DESCRIPTION
In order to follow the standard pattern in Jenkins plugins, the global configuration object should be accessed as a Singleton, as can be seen in numerous plugins, such as `git`, `git-client`, etc.

All the changes here reflect that same pattern.

### Testing done

* `mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed