### PR TITLE
Cache `zoneId` parsing to avoid repeated timezone resolution

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
@@ -126,7 +126,9 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
 
     @DataBoundSetter
     public void setTimeZone(String timeZone) {
-        this.timeZone = timeZone;
+        // Trim whitespace for convenience, but don't validate here
+        // Validation should be done via doCheckTimeZone() for UI feedback
+        this.timeZone = (timeZone != null) ? timeZone.trim() : null;
         // Clear cache when timezone changes
         cachedZoneId = null;
         cachedTimeZoneString = null;
@@ -179,11 +181,23 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
         Jenkins.get()
                 .checkAnyPermission(
                         Jenkins.ADMINISTER, Jenkins.SYSTEM_READ); // Admin permission required for global config
-        ZoneId zone = ZoneId.of(value);
-        if (StringUtils.equals(zone.getId(), value)) {
-            return FormValidation.ok();
-        } else {
-            return FormValidation.error(Messages.ScheduleBuildGlobalConfiguration_TimeZoneError());
+
+        // Check for null, empty, or whitespace-only values
+        if (value == null || value.trim().isEmpty()) {
+            return FormValidation.error("Timezone cannot be null, empty, or whitespace");
+        }
+
+        // Validate that it's a valid timezone
+        try {
+            ZoneId zone = ZoneId.of(value.trim());
+            // Additional check to ensure the timezone string is normalized
+            if (StringUtils.equals(zone.getId(), value.trim())) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.error(Messages.ScheduleBuildGlobalConfiguration_TimeZoneError());
+            }
+        } catch (DateTimeException e) {
+            return FormValidation.error("Invalid timezone: " + value);
         }
     }
 


### PR DESCRIPTION
The getZoneId() method was parsing the timezone string on every call using ZoneId.of(), which is expensive and includes exception handling. This method is called frequently from ScheduleBuildAction, causing unnecessary performance overhead.

### Testing done

* `mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed