### PR TITLE
[] Add the ability to set a time zone for the current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ the system time zone.
 
 ![](docs/images/Schedule_Timezone.png)
 
+### User-Specific Timezone Configuration
+
+Users can now configure their own timezone preference for schedule builds,
+overriding the global system setting. This allows users to schedule builds
+in their local timezone while maintaining the global system configuration
+for other users.
+
+To set your personal timezone preference:
+1. Go to your user profile page
+2. Click on "Schedule Build Preferences" in the left sidebar
+3. Select your preferred timezone from the dropdown
+4. Click "Save"
+
+If you don't set a custom timezone, the plugin will use the global system
+timezone setting.
+
 ## Configuration as code
 
 This plugin supports configuration as code
@@ -51,6 +67,10 @@ unclassified:
     defaultStartTime: "11:00:00 PM"
     timeZone: "Europe/Paris"
 ```
+
+**Note**: The global timezone setting can be overridden by individual users
+through their personal preferences. User-specific timezone settings are not
+configurable through configuration as code.
 
 ## Release Notes
 

--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildAction.java
@@ -5,8 +5,12 @@ import hudson.model.Descriptor.FormException;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.model.User;
 import hudson.util.FormValidation;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -88,18 +92,29 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
     }
 
     public ZonedDateTime getDefaultDateObject() {
-        ZonedDateTime zdt = ScheduleBuildGlobalConfiguration.get().getDefaultScheduleTimeObject();
+        ZonedDateTime zdt = getDefaultScheduleTimeObject();
         ZonedDateTime now = ZonedDateTime.now();
         if (now.isAfter(zdt)) {
             zdt = zdt.plusDays(1);
         }
         return zdt;
     }
+    
+    /**
+     * Get the default schedule time object using the user's preferred timezone if available,
+     * otherwise falling back to the global setting.
+     * @return the default schedule time in the appropriate timezone
+     */
+    private ZonedDateTime getDefaultScheduleTimeObject() {
+        ZoneId userZoneId = getUserTimeZone();
+        LocalTime defaultTime = ScheduleBuildGlobalConfiguration.get().getDefaultScheduleLocalTime();
+        return defaultTime.atDate(LocalDate.now()).atZone(userZoneId);
+    }
 
     public String getMinDate() {
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime zonedNow =
-                now.withZoneSameInstant(ScheduleBuildGlobalConfiguration.get().getZoneId());
+                now.withZoneSameInstant(getUserTimeZone());
         return zonedNow.format(DateTimeFormatter.ofPattern(DATE_TIME_PATTERN));
     }
 
@@ -114,7 +129,7 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
         ZonedDateTime ddate;
         try {
             ddate = parseDateTime(value.trim())
-                    .atZone(ScheduleBuildGlobalConfiguration.get().getZoneId())
+                    .atZone(getUserTimeZone())
                     .plusSeconds(SECURITY_MARGIN);
         } catch (DateTimeParseException ex) {
             return FormValidation.error(Messages.ScheduleBuildAction_ParsingError());
@@ -142,7 +157,7 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
         final String time = date.trim();
         try {
             ddate = parseDateTime(time)
-                    .atZone(ScheduleBuildGlobalConfiguration.get().getZoneId());
+                    .atZone(getUserTimeZone());
         } catch (DateTimeParseException ex) {
             LOGGER.log(Level.INFO, ex, () -> "Error parsing " + time);
             return HttpResponses.redirectTo("error");
@@ -183,6 +198,23 @@ public class ScheduleBuildAction implements Action, StaplerProxy, IconSpec {
 
     @Restricted(NoExternalUse.class)
     public String getTimeZone() {
-        return ScheduleBuildGlobalConfiguration.get().getTimeZone();
+        return getUserTimeZone().getId();
+    }
+    
+    /**
+     * Get the timezone to use for schedule builds.
+     * Returns the user's preferred timezone if set, otherwise falls back to the global setting.
+     * @return the ZoneId to use for schedule builds
+     */
+    private ZoneId getUserTimeZone() {
+        User currentUser = User.current();
+        if (currentUser != null) {
+            ScheduleBuildUserProperty userProperty = currentUser.getProperty(ScheduleBuildUserProperty.class);
+            if (userProperty != null && userProperty.hasCustomTimeZone()) {
+                return userProperty.getZoneId();
+            }
+        }
+        // Fall back to global setting
+        return ScheduleBuildGlobalConfiguration.get().getZoneId();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
@@ -132,6 +132,14 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
             return ZoneId.systemDefault();
         }
     }
+    
+    /**
+     * Get the default schedule local time.
+     * @return the default schedule local time
+     */
+    public LocalTime getDefaultScheduleLocalTime() {
+        return defaultScheduleLocalTime;
+    }
 
     private DateTimeFormatter getTimeFormatter() {
         return DateTimeFormatter.ofPattern(TIME_PATTERN);

--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildUserProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildUserProperty.java
@@ -1,0 +1,133 @@
+package org.jenkinsci.plugins.schedulebuild;
+
+import hudson.Extension;
+import hudson.model.User;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.*;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+import org.kohsuke.stapler.verb.POST;
+
+/**
+ * User property to store schedule build timezone preferences.
+ * Allows users to override the global timezone setting.
+ */
+public class ScheduleBuildUserProperty extends UserProperty {
+
+    private static final Logger LOGGER = Logger.getLogger(ScheduleBuildUserProperty.class.getName());
+    
+    private String timeZone;
+    
+    @DataBoundConstructor
+    public ScheduleBuildUserProperty() {
+        // Default to null, which means use global setting
+        this.timeZone = null;
+    }
+    
+    public ScheduleBuildUserProperty(String timeZone) {
+        this.timeZone = timeZone;
+    }
+    
+    /**
+     * Get the user's preferred timezone for schedule builds.
+     * @return the timezone ID, or null if using global setting
+     */
+    public String getTimeZone() {
+        return timeZone;
+    }
+    
+    @DataBoundSetter
+    public void setTimeZone(String timeZone) {
+        this.timeZone = timeZone;
+        // UserProperty is automatically saved when modified through the UI
+    }
+    
+    /**
+     * Get the ZoneId for the user's preferred timezone.
+     * Falls back to global setting if user hasn't set a preference.
+     * @return the ZoneId to use for schedule builds
+     */
+    public ZoneId getZoneId() {
+        if (timeZone != null && !timeZone.trim().isEmpty()) {
+            try {
+                return ZoneId.of(timeZone);
+            } catch (DateTimeException dte) {
+                LOGGER.warning("Invalid timezone '" + timeZone + "' for user " + user.getId() + ", falling back to global setting");
+            }
+        }
+        // Fall back to global setting
+        return ScheduleBuildGlobalConfiguration.get().getZoneId();
+    }
+    
+    /**
+     * Check if the user has set a custom timezone preference.
+     * @return true if user has set a custom timezone, false otherwise
+     */
+    public boolean hasCustomTimeZone() {
+        return timeZone != null && !timeZone.trim().isEmpty();
+    }
+    
+    @Extension
+    @Symbol("scheduleBuild")
+    public static class DescriptorImpl extends UserPropertyDescriptor {
+        
+        @Override
+        public String getDisplayName() {
+            return Messages.ScheduleBuildUserProperty_DisplayName();
+        }
+        
+        @Override
+        public boolean isEnabled() {
+            return Jenkins.get().hasPermission(Jenkins.SYSTEM_READ);
+        }
+        
+        @Override
+        public UserProperty newInstance(User user) {
+            return new ScheduleBuildUserProperty();
+        }
+        
+        @RequirePOST
+        public FormValidation doCheckTimeZone(@QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.ok(); // Empty is valid (use global setting)
+            }
+            
+            try {
+                ZoneId zone = ZoneId.of(value);
+                if (StringUtils.equals(zone.getId(), value)) {
+                    return FormValidation.ok();
+                } else {
+                    return FormValidation.error(Messages.ScheduleBuildUserProperty_TimeZoneError());
+                }
+            } catch (DateTimeException dte) {
+                return FormValidation.error(Messages.ScheduleBuildUserProperty_TimeZoneError());
+            }
+        }
+        
+        @POST
+        public ListBoxModel doFillTimeZoneItems() {
+            ListBoxModel items = new ListBoxModel();
+            
+            // Add option to use global setting
+            items.add(Messages.ScheduleBuildUserProperty_UseGlobalSetting(), "");
+            
+            // Add all available timezones
+            Set<String> zoneIds = new TreeSet<>(ZoneId.getAvailableZoneIds());
+            for (String id : zoneIds) {
+                items.add(id);
+            }
+            
+            return items;
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/schedulebuild/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/schedulebuild/Messages.properties
@@ -6,3 +6,7 @@ ScheduleBuildAction.DateInPastError = Build cannot be scheduled in the past
 
 ScheduleBuildGlobalConfiguration.ParsingError = Not a valid build time
 ScheduleBuildGlobalConfiguration.TimeZoneError = Not a valid time zone
+
+ScheduleBuildUserProperty.DisplayName = Schedule Build Preferences
+ScheduleBuildUserProperty.TimeZoneError = Not a valid time zone
+ScheduleBuildUserProperty.UseGlobalSetting = Use Global Setting

--- a/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildUserProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildUserProperty/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%ScheduleBuildTimeZone}" field="timeZone">
+    <f:select />
+    <f:description>
+      ${%ScheduleBuildTimeZoneDescription}
+    </f:description>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildUserProperty/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/schedulebuild/ScheduleBuildUserProperty/config.properties
@@ -1,0 +1,2 @@
+ScheduleBuildTimeZone = Schedule Build Time Zone
+ScheduleBuildTimeZoneDescription = Choose your preferred timezone for scheduling builds. Leave empty to use the global system setting.

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildActionTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.schedulebuild;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -10,10 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.FreeStyleProject;
+import hudson.model.User;
 import hudson.util.FormValidation;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import org.jenkinsci.plugins.schedulebuild.ScheduleBuildUserProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -137,5 +140,26 @@ class ScheduleBuildActionTest {
     void testDoNextDateInPast() {
         HttpResponse validation = scheduleBuildAction.doNext("01-01-2020 01:00:00", project);
         assertThat(validation, is(instanceOf(HttpRedirect.class)));
+    }
+    
+    @Test
+    void testGetTimeZone() {
+        // Should return the system default timezone when no user preference is set
+        String timeZone = scheduleBuildAction.getTimeZone();
+        assertThat(timeZone, is(not(nullValue())));
+        assertThat(timeZone, is(not("")));
+    }
+    
+    @Test
+    void testUserTimeZonePreference() throws Exception {
+        // Create a user with a custom timezone preference
+        User testUser = User.get("testuser");
+        ScheduleBuildUserProperty userProperty = new ScheduleBuildUserProperty("Europe/Berlin");
+        testUser.addProperty(userProperty);
+        
+        // Test that the user property works correctly
+        assertThat(userProperty.getTimeZone(), is("Europe/Berlin"));
+        assertThat(userProperty.hasCustomTimeZone(), is(true));
+        assertThat(userProperty.getZoneId().getId(), is("Europe/Berlin"));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildUserPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildUserPropertyTest.java
@@ -1,0 +1,120 @@
+package org.jenkinsci.plugins.schedulebuild;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.*;
+
+import hudson.model.User;
+import hudson.util.FormValidation;
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class ScheduleBuildUserPropertyTest {
+
+    private JenkinsRule j;
+    private User testUser;
+    private ScheduleBuildUserProperty userProperty;
+
+    @BeforeEach
+    void setUp(JenkinsRule j) throws Exception {
+        this.j = j;
+        testUser = User.get("testuser");
+        userProperty = new ScheduleBuildUserProperty();
+        testUser.addProperty(userProperty);
+    }
+
+    @Test
+    void testDefaultTimeZone() {
+        // Default should be null (use global setting)
+        assertThat(userProperty.getTimeZone(), is(nullValue()));
+        assertThat(userProperty.hasCustomTimeZone(), is(false));
+    }
+
+    @Test
+    void testSetCustomTimeZone() {
+        String customTimeZone = "Europe/Berlin";
+        userProperty.setTimeZone(customTimeZone);
+        
+        assertThat(userProperty.getTimeZone(), is(customTimeZone));
+        assertThat(userProperty.hasCustomTimeZone(), is(true));
+        assertThat(userProperty.getZoneId(), is(ZoneId.of(customTimeZone)));
+    }
+
+    @Test
+    void testSetEmptyTimeZone() {
+        userProperty.setTimeZone("");
+        
+        assertThat(userProperty.getTimeZone(), is(""));
+        assertThat(userProperty.hasCustomTimeZone(), is(false));
+        // Should fall back to global setting
+        assertThat(userProperty.getZoneId(), is(not(nullValue())));
+    }
+
+    @Test
+    void testSetNullTimeZone() {
+        userProperty.setTimeZone(null);
+        
+        assertThat(userProperty.getTimeZone(), is(nullValue()));
+        assertThat(userProperty.hasCustomTimeZone(), is(false));
+        // Should fall back to global setting
+        assertThat(userProperty.getZoneId(), is(not(nullValue())));
+    }
+
+    @Test
+    void testInvalidTimeZone() {
+        String invalidTimeZone = "Invalid/Timezone";
+        userProperty.setTimeZone(invalidTimeZone);
+        
+        // Should fall back to global setting even with invalid timezone
+        assertThat(userProperty.getZoneId(), is(not(nullValue())));
+    }
+
+    @Test
+    void testDescriptorValidation() {
+        ScheduleBuildUserProperty.DescriptorImpl descriptor = new ScheduleBuildUserProperty.DescriptorImpl();
+        
+        // Valid timezone
+        FormValidation validResult = descriptor.doCheckTimeZone("Europe/Berlin");
+        assertThat(validResult.kind, is(FormValidation.Kind.OK));
+        
+        // Empty timezone (use global setting)
+        FormValidation emptyResult = descriptor.doCheckTimeZone("");
+        assertThat(emptyResult.kind, is(FormValidation.Kind.OK));
+        
+        // Invalid timezone
+        FormValidation invalidResult = descriptor.doCheckTimeZone("Invalid/Timezone");
+        assertThat(invalidResult.kind, is(FormValidation.Kind.ERROR));
+    }
+
+    @Test
+    void testDescriptorTimeZoneItems() {
+        ScheduleBuildUserProperty.DescriptorImpl descriptor = new ScheduleBuildUserProperty.DescriptorImpl();
+        var items = descriptor.doFillTimeZoneItems();
+        
+        assertThat(items, is(not(nullValue())));
+        assertThat(items.size(), is(greaterThan(0)));
+        
+        // First item should be "Use Global Setting"
+        assertThat(items.get(0).name, is("Use Global Setting"));
+        assertThat(items.get(0).value, is(""));
+        
+        // Should contain common timezones
+        boolean hasEuropeBerlin = false;
+        boolean hasUTC = false;
+        for (var item : items) {
+            if ("Europe/Berlin".equals(item.value)) {
+                hasEuropeBerlin = true;
+            }
+            if ("UTC".equals(item.value)) {
+                hasUTC = true;
+            }
+        }
+        assertThat("Should contain Europe/Berlin", hasEuropeBerlin, is(true));
+        assertThat("Should contain UTC", hasUTC, is(true));
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

[JENKINS-71517](https://issues.jenkins.io/browse/JENKINS-71517?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20schedule-build-plugin)

Users can now set their own timezone preference for schedule builds, overriding the global system setting.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
