### PR TITLE
Persist timeZone as ZoneId directly

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/schedulebuild/ScheduleBuildGlobalConfiguration.java
@@ -45,7 +45,7 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
     // time portion (hours, minutes, seconds, etc.) while the date
     // portion is ignored.
     private transient Date defaultScheduleTime;
-    private String timeZone;
+    private ZoneId timeZone;
 
     private String defaultStartTime;
 
@@ -61,7 +61,7 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
 
     @DataBoundConstructor
     public ScheduleBuildGlobalConfiguration() {
-        this.timeZone = TimeZone.getDefault().getID();
+        this.timeZone = ZoneId.systemDefault();
         defaultStartTime = "22:00:00";
         load();
         defaultScheduleLocalTime = LocalTime.parse(defaultStartTime, getTimeFormatter());
@@ -116,21 +116,21 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
     }
 
     public String getTimeZone() {
-        return timeZone;
+        return timeZone.toString();
     }
 
     @DataBoundSetter
     public void setTimeZone(String timeZone) {
-        this.timeZone = timeZone;
+        try {
+            this.timeZone = ZoneId.of(timeZone);
+        } catch (DateTimeException e) {
+            this.timeZone = ZoneId.systemDefault();
+        }
         save();
     }
 
     public ZoneId getZoneId() {
-        try {
-            return ZoneId.of(timeZone);
-        } catch (DateTimeException dte) {
-            return ZoneId.systemDefault();
-        }
+        return timeZone;
     }
 
     private DateTimeFormatter getTimeFormatter() {
@@ -178,7 +178,7 @@ public class ScheduleBuildGlobalConfiguration extends GlobalConfiguration {
         ListBoxModel items = new ListBoxModel();
         Set<String> zoneIds = new TreeSet<>(ZoneId.getAvailableZoneIds());
         for (String id : zoneIds) {
-            if (id.equalsIgnoreCase(timeZone)) {
+            if (id.equalsIgnoreCase(timeZone.toString())) {
                 items.add(new ListBoxModel.Option(id, id, true));
             } else {
                 items.add(id);

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,2 @@
+java.time.ZoneRegion
+java.time.ZoneId


### PR DESCRIPTION
This avoids that the timezone needs to be parsed frequently. This change is compatible from api and persistence perspective so no extra conversion is required.
A change in core should be opened to allow the 2 classes generally that are now added explicitly.

Alternative to #425 

<!-- Please describe your pull request here. -->

### Testing done
Before this change configured the timezone to `Etc/GMT-9`, then started with this change and timezone is properly set to `Etc/GMT-9` in the UI and when scheduling a build. Also tested with other timezones in a similar way.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
